### PR TITLE
[Issue 05] Implementar middleware de autenticacao jwt

### DIFF
--- a/backend/apps/core/middleware.py
+++ b/backend/apps/core/middleware.py
@@ -1,0 +1,50 @@
+from django.db import connection, transaction
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework_simplejwt.authentication import JWTStatelessUserAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+
+
+class SessionContextMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.jwt_authentication = JWTStatelessUserAuthentication()
+
+    def __call__(self, request):
+        auth_result = self._authenticate_request(request)
+        is_authenticated = bool(getattr(request.user, "is_authenticated", False))
+        if auth_result is None or not is_authenticated:
+            return self.get_response(request)
+
+        _, token = auth_result
+        user_id = token["user_id"]
+        territorios = self._format_territorios(token.get("territorios", []))
+        role = str(token.get("role") or token.get("perfil") or "")
+
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute("SET LOCAL app.current_user_id = %s;", [str(user_id)])
+                cursor.execute("SET LOCAL app.user_territorios = %s;", [territorios])
+                cursor.execute("SET LOCAL app.user_role = %s;", [role])
+            return self.get_response(request)
+
+    def _authenticate_request(self, request):
+        try:
+            auth_result = self.jwt_authentication.authenticate(request)
+        except (AuthenticationFailed, InvalidToken, TokenError):
+            return None
+
+        if auth_result is None:
+            return None
+
+        request.user, request.auth = auth_result
+        return auth_result
+
+    @staticmethod
+    def _format_territorios(raw_territorios):
+        if raw_territorios is None:
+            return ""
+        if isinstance(raw_territorios, str):
+            return raw_territorios
+        if isinstance(raw_territorios, (list, tuple, set)):
+            return ",".join(str(territorio_id) for territorio_id in raw_territorios)
+        return str(raw_territorios)

--- a/backend/apps/core/tests.py
+++ b/backend/apps/core/tests.py
@@ -1,3 +1,38 @@
-from django.test import TestCase
+from contextlib import nullcontext
+import unittest
+from unittest.mock import MagicMock, call, patch
 
-# Create your tests here.
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from apps.core.middleware import SessionContextMiddleware
+
+
+class SessionContextMiddlewareTests(unittest.TestCase):
+    @patch("apps.core.middleware.transaction.atomic")
+    @patch("apps.core.middleware.connection.cursor")
+    @patch("apps.core.middleware.JWTStatelessUserAuthentication.authenticate")
+    def test_sets_local_session_variables_for_authenticated_request(
+        self, mock_authenticate, mock_cursor, mock_atomic
+    ):
+        mock_atomic.return_value = nullcontext()
+        request = RequestFactory().get("/api/v1/territorios/")
+        request.user = AnonymousUser()
+
+        authenticated_user = type("AuthenticatedUser", (), {"is_authenticated": True})()
+        token_payload = {"user_id": 9, "territorios": [3, 5, 8], "role": "gestor"}
+        mock_authenticate.return_value = (authenticated_user, token_payload)
+
+        get_response = MagicMock(return_value="ok")
+        middleware = SessionContextMiddleware(get_response)
+        response = middleware(request)
+
+        self.assertEqual(response, "ok")
+        cursor = mock_cursor.return_value.__enter__.return_value
+        cursor.execute.assert_has_calls(
+            [
+                call("SET LOCAL app.current_user_id = %s;", ["9"]),
+                call("SET LOCAL app.user_territorios = %s;", ["3,5,8"]),
+                call("SET LOCAL app.user_role = %s;", ["gestor"]),
+            ]
+        )

--- a/backend/setup/settings.py
+++ b/backend/setup/settings.py
@@ -61,6 +61,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "apps.core.middleware.SessionContextMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]


### PR DESCRIPTION
Implementa middleware Django para configurar variáveis de sessão no PostgreSQL por request autenticada, após validação de JWT via SimpleJWT.
 
 ### O que foi feito
 - Criado `backend/apps/core/middleware.py` com `PostgreSQLSessionVariablesMiddleware`.
 - Middleware extrai dados do payload JWT já decodificado (**sem query adicional ao banco**):
   - `user_id`
   - `territorios` (normalizado para CSV)
   - `role`/`perfil`
 - Executa, na mesma transação da request, via `connection.cursor()`:
   - `SET LOCAL app.current_user_id = %s`
   - `SET LOCAL app.user_territorios = %s`
   - `SET LOCAL app.user_role = %s`
 - Mantém comportamento **no-op** para endpoints públicos/requests não autenticadas (`request.user.is_authenticated == False`).
 - Registrado no `MIDDLEWARE` logo após `AuthenticationMiddleware` em `backend/setup/settings.py`.
 - Adicionado teste em `backend/apps/core/tests.py` validando que os 3 `SET LOCAL` são executados corretamente em request autenticada.
 
 Conforme requisitos de #5 