### PR TITLE
Issue #26: telas /dashboard, /esqueci-minha-senha e /redefinir-senha

### DIFF
--- a/frontend/app/(auth)/esqueci-minha-senha/page.tsx
+++ b/frontend/app/(auth)/esqueci-minha-senha/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import Link from "next/link";
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MENSAGEM_GENERICA =
+  "Se o e-mail estiver cadastrado, enviamos um link de redefinição.";
+
+function Spinner() {
+  return (
+    <svg
+      className="animate-spin h-4 w-4"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12" cy="12" r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}
+
+const inputBase =
+  "h-10 w-full rounded-md border px-3 text-sm text-foreground bg-surface outline-none transition" +
+  " focus:ring-2 focus:ring-primary/15 focus:border-primary" +
+  " border-border placeholder:text-text-muted";
+const inputErrorCls = "border-error focus:ring-error/20 focus:border-error";
+
+export default function EsqueciMinhaSenhaPage() {
+  const [pending, startTransition] = useTransition();
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [generalError, setGeneralError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const [retryAfter, setRetryAfter] = useState(0);
+
+  useEffect(() => {
+    if (retryAfter <= 0) return;
+    const id = setInterval(() => {
+      setRetryAfter((s) => {
+        if (s <= 1) { clearInterval(id); return 0; }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [retryAfter]);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (retryAfter > 0) return;
+
+    const email = (e.currentTarget.elements.namedItem("email") as HTMLInputElement).value.trim();
+
+    if (!EMAIL_RE.test(email)) {
+      setEmailError("Informe um e-mail válido.");
+      setGeneralError(null);
+      return;
+    }
+    setEmailError(null);
+    setGeneralError(null);
+
+    startTransition(async () => {
+      let res: Response;
+      try {
+        res = await fetch(`${BASE_URL}/api/v1/auth/password-reset/request/`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email }),
+        });
+      } catch {
+        setGeneralError("Não foi possível conectar ao servidor. Tente novamente.");
+        return;
+      }
+
+      if (res.status === 429) {
+        const retryHeader = res.headers.get("Retry-After");
+        const seconds = retryHeader ? parseInt(retryHeader, 10) : 60;
+        setRetryAfter(isNaN(seconds) ? 60 : seconds);
+        return;
+      }
+
+      setSubmitted(true);
+    });
+  }
+
+  const isBlocked = pending || retryAfter > 0;
+
+  return (
+    <>
+      <h1 className="text-2xl font-semibold text-foreground mb-1">
+        Recuperar senha
+      </h1>
+      <p className="text-sm text-text-muted mb-6">
+        Informe o e-mail da sua conta e enviaremos um link para redefinir sua senha.
+      </p>
+
+        {submitted ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="rounded-md border border-border bg-surface-muted px-3 py-3"
+          >
+            <p className="text-sm text-foreground">{MENSAGEM_GENERICA}</p>
+            <div className="mt-4">
+              <Link
+                href="/login"
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                Voltar para o login
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <>
+            {(generalError || retryAfter > 0) && (
+              <div
+                role="alert"
+                aria-live="polite"
+                className="mb-5 flex items-start gap-2 rounded-md border border-error bg-error-bg px-3 py-2.5"
+              >
+                <svg className="mt-0.5 h-4 w-4 shrink-0 text-error" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                </svg>
+                <p className="text-sm text-error">
+                  {retryAfter > 0
+                    ? `Muitas tentativas. Tente novamente em ${retryAfter} segundo${retryAfter !== 1 ? "s" : ""}.`
+                    : generalError}
+                </p>
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="flex flex-col gap-5" noValidate>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="email" className="text-sm font-medium text-foreground">
+                  E-mail
+                </label>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  aria-invalid={!!emailError}
+                  aria-describedby={emailError ? "error-email" : undefined}
+                  className={`${inputBase} ${emailError ? inputErrorCls : ""}`}
+                />
+                {emailError && (
+                  <p id="error-email" className="text-xs text-error mt-0.5">{emailError}</p>
+                )}
+              </div>
+
+              <button
+                type="submit"
+                disabled={isBlocked}
+                className="mt-1 h-10 rounded-md bg-primary text-white text-sm font-medium flex items-center justify-center gap-2 transition-colors hover:bg-primary-hover disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {pending ? (
+                  <>
+                    <Spinner />
+                    <span>Enviando...</span>
+                  </>
+                ) : (
+                  "Enviar link de redefinição"
+                )}
+              </button>
+
+              <div className="text-center">
+                <Link
+                  href="/login"
+                  className="text-sm text-text-muted hover:text-primary transition-colors"
+                >
+                  Voltar para o login
+                </Link>
+              </div>
+            </form>
+          </>
+        )}
+    </>
+  );
+}

--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -1,0 +1,91 @@
+import type { ReactNode } from "react";
+
+const PILARES = [
+  "Territórios",
+  "Famílias",
+  "Cadeias produtivas",
+  "Eventos e atividades",
+];
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] bg-background">
+      <aside className="hidden lg:flex flex-col justify-between bg-primary text-white px-12 py-10 relative overflow-hidden">
+        <div
+          aria-hidden="true"
+          className="absolute -top-32 -right-32 h-96 w-96 rounded-full bg-white/5 blur-3xl"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute -bottom-40 -left-20 h-80 w-80 rounded-full bg-white/5 blur-3xl"
+        />
+
+        <header className="relative flex items-center gap-2">
+          <svg
+            viewBox="0 0 24 24"
+            className="h-7 w-7"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.75}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 3 L20 19 L4 19 Z"
+            />
+          </svg>
+          <span className="text-xl font-semibold tracking-tight">
+            PDHC <span className="font-light italic lowercase opacity-80">iii</span>
+          </span>
+        </header>
+
+        <div className="relative max-w-md">
+          <h2 className="text-3xl font-semibold leading-tight text-balance">
+            Plataforma de Desenvolvimento das Cadeias Produtivas
+          </h2>
+          <p className="mt-3 text-base text-white/75 leading-relaxed">
+            Da agricultura familiar do semiárido brasileiro.
+          </p>
+        </div>
+
+        <ul className="relative space-y-2 text-sm text-white/70">
+          {PILARES.map((p) => (
+            <li key={p} className="flex items-center gap-2">
+              <span aria-hidden="true" className="h-1 w-1 rounded-full bg-white/60" />
+              {p}
+            </li>
+          ))}
+        </ul>
+      </aside>
+
+      <main className="flex items-center justify-center px-4 py-10 lg:px-12">
+        <div className="w-full max-w-sm">
+          <div className="lg:hidden flex items-center justify-center gap-2 mb-8 text-primary">
+            <svg
+              viewBox="0 0 24 24"
+              className="h-6 w-6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.75}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 3 L20 19 L4 19 Z"
+              />
+            </svg>
+            <span className="text-lg font-semibold tracking-tight">
+              PDHC <span className="font-light italic lowercase opacity-80">iii</span>
+            </span>
+          </div>
+
+          <div className="bg-surface rounded-lg border border-border shadow-sm p-8">
+            {children}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -40,6 +40,7 @@ function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const next = searchParams.get("next") ?? "/dashboard";
+  const resetSuccess = searchParams.get("reset") === "ok";
 
   const [pending, startTransition] = useTransition();
   const [globalError, setGlobalError] = useState<string | null>(null);
@@ -141,17 +142,23 @@ function LoginForm() {
   const inputErrorCls = "border-error focus:ring-error/20 focus:border-error";
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background px-4">
-      <div className="w-full max-w-sm bg-surface rounded-lg border border-border shadow-sm p-8">
+    <>
+      <h1 className="text-2xl font-semibold text-foreground mb-1">Entrar</h1>
+      <p className="text-sm text-text-muted mb-6">
+        Acesse seu painel do PDHC iii.
+      </p>
 
-        {/* TODO: substituir pelo componente <Logo /> quando o arquivo da marca estiver disponível */}
-        <div className="flex justify-center mb-7">
-          <div className="w-32 h-12 bg-surface-muted rounded flex items-center justify-center">
-            <span className="text-xs text-text-muted select-none">Logo PDHC</span>
+        {resetSuccess && !globalError && retryAfter === 0 && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mb-5 rounded-md border border-success bg-surface-muted px-3 py-2.5"
+          >
+            <p className="text-sm text-foreground">
+              Senha redefinida com sucesso. Faça login com a nova senha.
+            </p>
           </div>
-        </div>
-
-        <h1 className="text-xl font-semibold text-primary mb-6">Entrar</h1>
+        )}
 
         {/* Erro geral — aria-live para leitores de tela (PDHC seção 9.5) */}
         {(globalError || retryAfter > 0) && (
@@ -235,8 +242,7 @@ function LoginForm() {
             </Link>
           </div>
         </form>
-      </div>
-    </div>
+    </>
   );
 }
 

--- a/frontend/app/(auth)/redefinir-senha/page.tsx
+++ b/frontend/app/(auth)/redefinir-senha/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { Suspense, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+function validatePassword(senha: string): string | null {
+  if (senha.length < 10) return "A senha deve ter no mínimo 10 caracteres.";
+  if (!/[A-Z]/.test(senha)) return "A senha deve conter pelo menos 1 letra maiúscula.";
+  if (!/[0-9]/.test(senha)) return "A senha deve conter pelo menos 1 número.";
+  return null;
+}
+
+function Spinner() {
+  return (
+    <svg
+      className="animate-spin h-4 w-4"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12" cy="12" r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}
+
+const inputBase =
+  "h-10 w-full rounded-md border px-3 text-sm text-foreground bg-surface outline-none transition" +
+  " focus:ring-2 focus:ring-primary/15 focus:border-primary" +
+  " border-border placeholder:text-text-muted";
+const inputErrorCls = "border-error focus:ring-error/20 focus:border-error";
+
+type FieldErrors = { senha?: string; confirm?: string };
+
+function RedefinirSenhaForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [pending, startTransition] = useTransition();
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [tokenInvalido, setTokenInvalido] = useState(false);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const form = e.currentTarget;
+    const senha = (form.elements.namedItem("senha") as HTMLInputElement).value;
+    const confirm = (form.elements.namedItem("confirm") as HTMLInputElement).value;
+
+    const errs: FieldErrors = {};
+    const senhaErr = validatePassword(senha);
+    if (senhaErr) errs.senha = senhaErr;
+    if (confirm !== senha) errs.confirm = "As senhas não coincidem.";
+
+    if (Object.keys(errs).length > 0) {
+      setFieldErrors(errs);
+      setGlobalError(null);
+      setTokenInvalido(false);
+      return;
+    }
+    setFieldErrors({});
+    setGlobalError(null);
+    setTokenInvalido(false);
+
+    if (!token) {
+      setGlobalError("Token de redefinição ausente. Solicite um novo link.");
+      setTokenInvalido(true);
+      return;
+    }
+
+    startTransition(async () => {
+      let res: Response;
+      try {
+        res = await fetch(`${BASE_URL}/api/v1/auth/password-reset/confirm/`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token, nova_senha: senha }),
+        });
+      } catch {
+        setGlobalError("Não foi possível conectar ao servidor. Tente novamente.");
+        return;
+      }
+
+      if (res.ok) {
+        router.push("/login?reset=ok");
+        return;
+      }
+
+      if (res.status === 400) {
+        try {
+          const body: { code?: string; message?: string } = await res.json();
+          if (body.code === "INVALID_TOKEN" || body.code === "EXPIRED_TOKEN") {
+            setGlobalError(body.message ?? "Link inválido ou expirado.");
+            setTokenInvalido(true);
+            return;
+          }
+          setGlobalError(body.message ?? "Não foi possível redefinir a senha.");
+        } catch {
+          setGlobalError("Não foi possível redefinir a senha.");
+        }
+        return;
+      }
+
+      setGlobalError("Erro inesperado. Tente novamente.");
+    });
+  }
+
+  return (
+    <>
+      <h1 className="text-2xl font-semibold text-foreground mb-1">
+        Redefinir senha
+      </h1>
+      <p className="text-sm text-text-muted mb-6">
+        Escolha uma nova senha com no mínimo 10 caracteres, 1 letra maiúscula e 1 número.
+      </p>
+
+        {globalError && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="mb-5 rounded-md border border-error bg-error-bg px-3 py-2.5"
+          >
+            <div className="flex items-start gap-2">
+              <svg className="mt-0.5 h-4 w-4 shrink-0 text-error" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+              <p className="text-sm text-error">{globalError}</p>
+            </div>
+            {tokenInvalido && (
+              <div className="mt-2 pl-6">
+                <Link
+                  href="/esqueci-minha-senha"
+                  className="text-sm font-medium text-error hover:underline"
+                >
+                  Solicitar novo link
+                </Link>
+              </div>
+            )}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5" noValidate>
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="senha" className="text-sm font-medium text-foreground">
+              Nova senha
+            </label>
+            <input
+              id="senha"
+              name="senha"
+              type="password"
+              autoComplete="new-password"
+              required
+              aria-invalid={!!fieldErrors.senha}
+              aria-describedby={fieldErrors.senha ? "error-senha" : undefined}
+              className={`${inputBase} ${fieldErrors.senha ? inputErrorCls : ""}`}
+            />
+            {fieldErrors.senha && (
+              <p id="error-senha" className="text-xs text-error mt-0.5">{fieldErrors.senha}</p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="confirm" className="text-sm font-medium text-foreground">
+              Confirmar nova senha
+            </label>
+            <input
+              id="confirm"
+              name="confirm"
+              type="password"
+              autoComplete="new-password"
+              required
+              aria-invalid={!!fieldErrors.confirm}
+              aria-describedby={fieldErrors.confirm ? "error-confirm" : undefined}
+              className={`${inputBase} ${fieldErrors.confirm ? inputErrorCls : ""}`}
+            />
+            {fieldErrors.confirm && (
+              <p id="error-confirm" className="text-xs text-error mt-0.5">{fieldErrors.confirm}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={pending}
+            className="mt-1 h-10 rounded-md bg-primary text-white text-sm font-medium flex items-center justify-center gap-2 transition-colors hover:bg-primary-hover disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {pending ? (
+              <>
+                <Spinner />
+                <span>Redefinindo...</span>
+              </>
+            ) : (
+              "Redefinir senha"
+            )}
+          </button>
+        </form>
+    </>
+  );
+}
+
+export default function RedefinirSenhaPage() {
+  return (
+    <Suspense>
+      <RedefinirSenhaForm />
+    </Suspense>
+  );
+}

--- a/frontend/app/(protected)/dashboard/logout-button.tsx
+++ b/frontend/app/(protected)/dashboard/logout-button.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useTransition } from "react";
+import { logout } from "@/app/lib/api";
+
+export function LogoutButton() {
+  const [pending, startTransition] = useTransition();
+
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={() => startTransition(() => logout())}
+      className="h-9 px-4 rounded-md border border-border bg-surface text-sm font-medium text-foreground hover:bg-surface-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? "Saindo..." : "Sair"}
+    </button>
+  );
+}

--- a/frontend/app/(protected)/dashboard/page.tsx
+++ b/frontend/app/(protected)/dashboard/page.tsx
@@ -1,73 +1,212 @@
-import { auth, signOut } from "@/auth";
+import { auth } from "@/auth";
 import { redirect } from "next/navigation";
+import { LogoutButton } from "./logout-button";
+
+type CardIcon = "users" | "calendar" | "megaphone" | "clipboard";
+
+const PLACEHOLDER_CARDS: { label: string; icon: CardIcon }[] = [
+  { label: "Famílias atendidas", icon: "users" },
+  { label: "Atividades", icon: "calendar" },
+  { label: "Eventos", icon: "megaphone" },
+  { label: "Demandas", icon: "clipboard" },
+];
+
+function getIniciais(nome: string): string {
+  const partes = nome.split(" ").filter(Boolean);
+  if (partes.length === 0) return "?";
+  if (partes.length === 1) return partes[0][0]?.toUpperCase() ?? "?";
+  return (
+    (partes[0][0] ?? "") + (partes[partes.length - 1][0] ?? "")
+  ).toUpperCase();
+}
+
+function getPrimeiroNome(nome: string): string {
+  return nome.split(" ").filter(Boolean)[0] ?? "";
+}
+
+function getSaudacao(date: Date = new Date()): string {
+  const h = date.getHours();
+  if (h >= 5 && h < 12) return "Bom dia";
+  if (h >= 12 && h < 18) return "Boa tarde";
+  return "Boa noite";
+}
+
+function CardIconSvg({ name }: { name: CardIcon }) {
+  const props = {
+    viewBox: "0 0 24 24",
+    fill: "none" as const,
+    stroke: "currentColor",
+    strokeWidth: 1.5,
+    className: "h-5 w-5",
+    "aria-hidden": true,
+  };
+  switch (name) {
+    case "users":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"
+          />
+        </svg>
+      );
+    case "calendar":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+          />
+        </svg>
+      );
+    case "megaphone":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"
+          />
+        </svg>
+      );
+    case "clipboard":
+      return (
+        <svg {...props}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2Z"
+          />
+        </svg>
+      );
+  }
+}
+
+function BrandMark() {
+  return (
+    <div className="flex items-center gap-2 text-primary">
+      <svg
+        viewBox="0 0 24 24"
+        className="h-6 w-6"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.75}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 3 L20 19 L4 19 Z"
+        />
+      </svg>
+      <span className="text-base font-semibold tracking-tight">
+        PDHC <span className="font-light italic lowercase opacity-80">iii</span>
+      </span>
+    </div>
+  );
+}
 
 export default async function DashboardPage() {
   const session = await auth();
-
   if (!session) redirect("/login");
 
+  const { nome_completo, foto_url, perfis } = session.user;
+  const nome = nome_completo || "Usuário";
+  const primeiroNome = getPrimeiroNome(nome) || "por aqui";
+  const iniciais = getIniciais(nome);
+  const saudacao = getSaudacao();
+
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 p-8">
-      <div className="max-w-3xl mx-auto">
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
-            Dashboard
-          </h1>
-          <form
-            action={async () => {
-              "use server";
-              await signOut({ redirectTo: "/login" });
-            }}
-          >
-            <button
-              type="submit"
-              className="h-9 px-4 rounded-full border border-zinc-200 dark:border-zinc-700 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border bg-surface">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between gap-4">
+          <BrandMark />
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="flex items-center gap-3 min-w-0">
+              {foto_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={foto_url}
+                  alt=""
+                  className="h-9 w-9 rounded-full object-cover border border-border shrink-0"
+                />
+              ) : (
+                <div
+                  aria-hidden="true"
+                  className="h-9 w-9 rounded-full bg-primary text-white text-xs font-medium flex items-center justify-center shrink-0"
+                >
+                  {iniciais}
+                </div>
+              )}
+              <div className="min-w-0 hidden sm:block">
+                <p className="text-sm font-medium text-foreground truncate leading-tight">
+                  {nome}
+                </p>
+                {perfis && perfis.length > 0 ? (
+                  <ul className="mt-1 flex flex-wrap gap-1">
+                    {perfis.map((perfil) => (
+                      <li
+                        key={perfil}
+                        className="px-1.5 py-0.5 rounded-full bg-surface-muted text-[10px] font-medium uppercase tracking-wide text-text-muted border border-border"
+                      >
+                        {perfil}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+            </div>
+            <LogoutButton />
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        <section className="relative overflow-hidden rounded-lg border border-border bg-primary text-white p-6 sm:p-8">
+          <div
+            aria-hidden="true"
+            className="absolute -top-20 -right-20 h-64 w-64 rounded-full bg-white/10 blur-3xl"
+          />
+          <div className="relative">
+            <p className="text-sm text-white/80 uppercase tracking-wider font-medium">
+              Painel · Sprint 1
+            </p>
+            <h1 className="mt-2 text-2xl sm:text-3xl font-semibold leading-tight">
+              {saudacao}, {primeiroNome}.
+            </h1>
+            <p className="mt-2 text-sm text-white/80 max-w-md">
+              Seu painel está em construção. As métricas dos módulos aparecerão aqui
+              conforme forem entregues.
+            </p>
+          </div>
+        </section>
+
+        <section
+          aria-label="Indicadores"
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"
+        >
+          {PLACEHOLDER_CARDS.map((card) => (
+            <div
+              key={card.label}
+              className="group rounded-lg border border-border bg-surface p-5 transition-colors hover:border-primary/40"
             >
-              Sair
-            </button>
-          </form>
-        </div>
-
-        <div className="bg-white dark:bg-zinc-800 rounded-xl border border-zinc-200 dark:border-zinc-700 p-6 space-y-4">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500 mb-1">
-              Usuário
-            </p>
-            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
-              {session.user.username}
-            </p>
-          </div>
-
-          <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500 mb-1">
-              E-mail
-            </p>
-            <p className="text-sm text-zinc-700 dark:text-zinc-300">
-              {session.user.email || "—"}
-            </p>
-          </div>
-
-          <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500 mb-2">
-              Permissões
-            </p>
-            {(session.user.permissions ?? []).length === 0 ? (
-              <p className="text-sm text-zinc-500 dark:text-zinc-400">Nenhuma permissão atribuída.</p>
-            ) : (
-              <ul className="flex flex-wrap gap-2">
-                {(session.user.permissions ?? []).map((perm) => (
-                  <li
-                    key={perm}
-                    className="px-2 py-0.5 rounded bg-zinc-100 dark:bg-zinc-700 text-xs text-zinc-700 dark:text-zinc-300 font-mono"
-                  >
-                    {perm}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        </div>
-      </div>
+              <div className="flex items-center justify-between">
+                <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
+                  {card.label}
+                </p>
+                <span className="text-primary opacity-60 group-hover:opacity-100 transition-opacity">
+                  <CardIconSvg name={card.icon} />
+                </span>
+              </div>
+              <p className="mt-3 text-3xl font-semibold text-foreground tabular-nums">
+                —
+              </p>
+            </div>
+          ))}
+        </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
- /dashboard: header com avatar/nome/perfis e botão Sair (chama logout() da #8); hero com saudação personalizada; cards placeholder de Famílias atendidas, Atividades, Eventos e Demandas.
- /esqueci-minha-senha: form com e-mail, POST /api/v1/auth/password-reset/ request/, mensagem genérica anti-enumeration, 429 com countdown e botão desabilitado.
- /redefinir-senha: lê ?token= da URL, validação client-side (mín 10 chars, 1 maiúscula, 1 número), POST /api/v1/auth/password-reset/confirm/, 200 redireciona para /login?reset=ok, 400 (INVALID_TOKEN/EXPIRED_TOKEN) exibe mensagem do backend + link "Solicitar novo link".
- /login: ajuste para exibir banner verde quando ?reset=ok ("Senha redefinida com sucesso. Faça login com a nova senha.").
- Layout compartilhado /(auth)/layout.tsx com painel lateral institucional e identidade visual PDHC iii.

Testado localmente de ponta a ponta com backend Django + Postgres + Redis
+ Celery.