### PR TITLE
Frontend/issue51

### DIFF
--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -1,29 +1,31 @@
 import type { ReactNode } from "react";
 
-const PILARES = [
-  "Territórios",
-  "Famílias",
-  "Cadeias produtivas",
-  "Eventos e atividades",
-];
-
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] bg-bg">
-      <aside className="hidden lg:flex flex-col justify-between bg-primary text-white px-12 py-10 relative overflow-hidden">
+      <aside className="hidden lg:flex flex-col justify-between relative overflow-hidden px-14 py-12 text-white bg-[#0d2e1d]">
         <div
           aria-hidden="true"
-          className="absolute -top-32 -right-32 h-96 w-96 rounded-full bg-white/5 blur-3xl"
+          className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(74,124,89,0.35),transparent_60%)]"
         />
         <div
           aria-hidden="true"
-          className="absolute -bottom-40 -left-20 h-80 w-80 rounded-full bg-white/5 blur-3xl"
+          className="absolute inset-0 bg-[radial-gradient(circle_at_80%_80%,rgba(27,94,59,0.45),transparent_55%)]"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 opacity-[0.025]"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 1px 1px, white 1px, transparent 0)",
+            backgroundSize: "28px 28px",
+          }}
         />
 
-        <header className="relative flex items-center gap-2">
+        <header className="relative flex items-center gap-2.5">
           <svg
             viewBox="0 0 24 24"
-            className="h-7 w-7"
+            className="h-7 w-7 text-white/90"
             fill="none"
             stroke="currentColor"
             strokeWidth={1.75}
@@ -35,33 +37,32 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
               d="M12 3 L20 19 L4 19 Z"
             />
           </svg>
-          <span className="text-xl font-semibold tracking-tight">
-            PDHC <span className="font-light italic lowercase opacity-80">iii</span>
+          <span className="text-lg font-semibold tracking-tight">
+            PDHC{" "}
+            <span className="font-light italic lowercase opacity-70">iii</span>
           </span>
         </header>
 
         <div className="relative max-w-md">
-          <h2 className="text-3xl font-semibold leading-tight text-balance">
-            Plataforma de Desenvolvimento das Cadeias Produtivas
+          <h2 className="text-5xl font-semibold leading-[1.05] tracking-tight">
+            Cadeias produtivas
+            <br />
+            <span className="text-white/60">da agricultura familiar.</span>
           </h2>
-          <p className="mt-3 text-base text-white/75 leading-relaxed">
-            Da agricultura familiar do semiárido brasileiro.
+          <p className="mt-5 text-sm text-white/55 leading-relaxed max-w-sm">
+            Plataforma do Programa de Desenvolvimento Humano das Cadeias
+            Produtivas no semiárido brasileiro.
           </p>
         </div>
 
-        <ul className="relative space-y-2 text-sm text-white/70">
-          {PILARES.map((p) => (
-            <li key={p} className="flex items-center gap-2">
-              <span aria-hidden="true" className="h-1 w-1 rounded-full bg-white/60" />
-              {p}
-            </li>
-          ))}
-        </ul>
+        <p className="relative text-[11px] tracking-[0.2em] uppercase text-white/35 font-medium">
+          Ecossistema PDHC III
+        </p>
       </aside>
 
-      <main className="flex items-center justify-center px-4 py-10 lg:px-12">
-        <div className="w-full max-w-sm">
-          <div className="lg:hidden flex items-center justify-center gap-2 mb-8 text-primary">
+      <main className="flex items-center justify-center px-6 py-12 lg:px-16">
+        <div className="w-full max-w-[420px]">
+          <div className="lg:hidden flex items-center justify-center gap-2 mb-10 text-primary">
             <svg
               viewBox="0 0 24 24"
               className="h-6 w-6"
@@ -77,13 +78,14 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
               />
             </svg>
             <span className="text-lg font-semibold tracking-tight">
-              PDHC <span className="font-light italic lowercase opacity-80">iii</span>
+              PDHC{" "}
+              <span className="font-light italic lowercase opacity-70">
+                iii
+              </span>
             </span>
           </div>
 
-          <div className="bg-surface rounded-lg border border-border shadow-sm p-8">
-            {children}
-          </div>
+          {children}
         </div>
       </main>
     </div>

--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] bg-bg">
+    <div className="min-h-screen grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
       <aside className="hidden lg:flex flex-col justify-between relative overflow-hidden px-14 py-12 text-white bg-[#0d2e1d]">
         <div
           aria-hidden="true"

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -21,14 +21,16 @@ function LoginForm() {
   const [pending, startTransition] = useTransition();
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
-  // Countdown para 429 — enquanto > 0, botão fica bloqueado
   const [retryAfter, setRetryAfter] = useState(0);
 
   useEffect(() => {
     if (retryAfter <= 0) return;
     const id = setInterval(() => {
       setRetryAfter((s) => {
-        if (s <= 1) { clearInterval(id); return 0; }
+        if (s <= 1) {
+          clearInterval(id);
+          return 0;
+        }
         return s - 1;
       });
     }, 1000);
@@ -47,8 +49,11 @@ function LoginForm() {
     if (retryAfter > 0) return;
 
     const form = e.currentTarget;
-    const email = (form.elements.namedItem("email") as HTMLInputElement).value.trim();
-    const password = (form.elements.namedItem("password") as HTMLInputElement).value;
+    const email = (
+      form.elements.namedItem("email") as HTMLInputElement
+    ).value.trim();
+    const password = (form.elements.namedItem("password") as HTMLInputElement)
+      .value;
 
     const errs = validate(email, password);
     if (Object.keys(errs).length > 0) {
@@ -60,7 +65,6 @@ function LoginForm() {
     setGlobalError(null);
 
     startTransition(async () => {
-      // Passo 1 — chama o Django diretamente para ter acesso ao body completo da resposta
       let res: Response;
       try {
         res = await fetch(`${BASE_URL}/api/v1/auth/login/`, {
@@ -69,7 +73,9 @@ function LoginForm() {
           body: JSON.stringify({ email, senha: password }),
         });
       } catch {
-        setGlobalError("Não foi possível conectar ao servidor. Tente novamente.");
+        setGlobalError(
+          "Não foi possível conectar ao servidor. Tente novamente.",
+        );
         return;
       }
 
@@ -82,18 +88,20 @@ function LoginForm() {
 
       if (!res.ok) {
         try {
-          // Arq. §5 define {code, message}. Simple JWT usa {detail} — fallback para compatibilidade
-          const body: { code?: string; message?: string; detail?: string } = await res.json();
-          setGlobalError(body.message ?? body.detail ?? "Usuário ou senha inválidos.");
+          const body: { code?: string; message?: string; detail?: string } =
+            await res.json();
+          setGlobalError(
+            body.message ?? body.detail ?? "Usuário ou senha inválidos.",
+          );
         } catch {
           setGlobalError("Usuário ou senha inválidos.");
         }
         return;
       }
 
-      const tokens: { access_token: string; refresh_token: string } = await res.json();
+      const tokens: { access_token: string; refresh_token: string } =
+        await res.json();
 
-      // Passo 2 — entrega os tokens ao next-auth para criar a sessão (cookies HTTP-only)
       const result = await signIn("credentials", {
         access: tokens.access_token,
         refresh: tokens.refresh_token,
@@ -112,112 +120,136 @@ function LoginForm() {
   const isBlocked = pending || retryAfter > 0;
 
   const inputBase =
-    "h-10 w-full rounded-md border px-3 text-sm text-text bg-surface outline-none transition" +
-    " focus:ring-2 focus:ring-primary/15 focus:border-primary" +
-    " border-border placeholder:text-text-muted";
-  const inputErrorCls = "border-error focus:ring-error/20 focus:border-error";
+    "h-12 w-full rounded-lg border border-border bg-transparent px-4 text-sm text-text outline-none placeholder:text-text-muted/70 transition" +
+    " hover:border-text-muted/60 focus:border-primary focus:bg-surface focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-primary)_10%,transparent)]";
+  const inputErrorCls =
+    "border-error-text focus:border-error-text focus:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-error-text)_10%,transparent)]";
 
   return (
     <>
-      <h1 className="text-2xl font-semibold text-text mb-1">Entrar</h1>
-      <p className="text-sm text-text-muted mb-6">
-        Acesse seu painel do PDHC iii.
-      </p>
+      <div className="mb-10">
+        <h1 className="text-4xl font-semibold text-text leading-tight tracking-tight">
+          Entrar
+        </h1>
+        <p className="mt-3 text-sm text-text-muted">
+          Acesse o painel com suas credenciais.
+        </p>
+      </div>
 
-        {resetSuccess && !globalError && retryAfter === 0 && (
-          <div
-            role="status"
-            aria-live="polite"
-            className="mb-5 rounded-md border border-success bg-surface-muted px-3 py-2.5"
+      {resetSuccess && !globalError && retryAfter === 0 && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="mb-6 rounded-lg bg-success-bg/60 px-3.5 py-2.5"
+        >
+          <p className="text-sm text-success-text">
+            Senha redefinida com sucesso. Faça login com a nova senha.
+          </p>
+        </div>
+      )}
+
+      {(globalError || retryAfter > 0) && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="mb-6 flex items-start gap-2 rounded-lg bg-error-bg/60 px-3.5 py-2.5"
+        >
+          <svg
+            className="mt-0.5 h-4 w-4 shrink-0 text-error-text"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
           >
-            <p className="text-sm text-text">
-              Senha redefinida com sucesso. Faça login com a nova senha.
-            </p>
-          </div>
-        )}
-
-        {/* Erro geral — aria-live para leitores de tela (PDHC seção 9.5) */}
-        {(globalError || retryAfter > 0) && (
-          <div
-            role="alert"
-            aria-live="polite"
-            className="mb-5 flex items-start gap-2 rounded-md border border-error bg-error-bg px-3 py-2.5"
-          >
-            <svg className="mt-0.5 h-4 w-4 shrink-0 text-error" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
-            </svg>
-            <p className="text-sm text-error">
-              {retryAfter > 0
-                ? `Muitas tentativas. Tente novamente em ${retryAfter} segundo${retryAfter !== 1 ? "s" : ""}.`
-                : globalError}
-            </p>
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="flex flex-col gap-5" noValidate>
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="email" className="text-sm font-medium text-text">
-              E-mail
-            </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              required
-              aria-invalid={!!fieldErrors.email}
-              aria-describedby={fieldErrors.email ? "error-email" : undefined}
-              className={`${inputBase} ${fieldErrors.email ? inputErrorCls : ""}`}
+            <path
+              fillRule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+              clipRule="evenodd"
             />
-            {fieldErrors.email && (
-              <p id="error-email" className="text-xs text-error mt-0.5">{fieldErrors.email}</p>
-            )}
-          </div>
+          </svg>
+          <p className="text-sm text-error-text">
+            {retryAfter > 0
+              ? `Muitas tentativas. Tente novamente em ${retryAfter} segundo${retryAfter !== 1 ? "s" : ""}.`
+              : globalError}
+          </p>
+        </div>
+      )}
 
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="password" className="text-sm font-medium text-text">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5" noValidate>
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="email"
+            className="text-xs font-medium uppercase tracking-[0.15em] text-text-muted"
+          >
+            E-mail
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            placeholder="seu.email@dominio.com"
+            required
+            aria-invalid={!!fieldErrors.email}
+            aria-describedby={fieldErrors.email ? "error-email" : undefined}
+            className={`${inputBase} ${fieldErrors.email ? inputErrorCls : ""}`}
+          />
+          {fieldErrors.email && (
+            <p id="error-email" className="text-xs text-error-text">
+              {fieldErrors.email}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="flex items-baseline justify-between">
+            <label
+              htmlFor="password"
+              className="text-xs font-medium uppercase tracking-[0.15em] text-text-muted"
+            >
               Senha
             </label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              autoComplete="current-password"
-              required
-              aria-invalid={!!fieldErrors.password}
-              aria-describedby={fieldErrors.password ? "error-password" : undefined}
-              className={`${inputBase} ${fieldErrors.password ? inputErrorCls : ""}`}
-            />
-            {fieldErrors.password && (
-              <p id="error-password" className="text-xs text-error mt-0.5">{fieldErrors.password}</p>
-            )}
-          </div>
-
-          {/* Botão primário PDHC — fundo #1B5E3B, border-radius 6px (seção 6.1) */}
-          <button
-            type="submit"
-            disabled={isBlocked}
-            className="mt-1 h-10 rounded-md bg-primary text-white text-sm font-medium flex items-center justify-center gap-2 transition-colors hover:bg-secondary disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            {pending ? (
-              <>
-                <Spinner />
-                <span>Entrando...</span>
-              </>
-            ) : (
-              "Entrar"
-            )}
-          </button>
-
-          <div className="text-center">
             <Link
               href="/esqueci-minha-senha"
-              className="text-sm text-text-muted hover:text-primary transition-colors"
+              className="text-xs text-text-muted hover:text-primary transition-colors"
             >
               Esqueci minha senha
             </Link>
           </div>
-        </form>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            placeholder="••••••••"
+            required
+            aria-invalid={!!fieldErrors.password}
+            aria-describedby={
+              fieldErrors.password ? "error-password" : undefined
+            }
+            className={`${inputBase} ${fieldErrors.password ? inputErrorCls : ""}`}
+          />
+          {fieldErrors.password && (
+            <p id="error-password" className="text-xs text-error-text">
+              {fieldErrors.password}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isBlocked}
+          className="mt-3 h-12 rounded-lg bg-gradient-to-br from-primary to-secondary text-white text-sm font-medium tracking-wide flex items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-primary/25 active:shadow-md disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:shadow-none"
+        >
+          {pending ? (
+            <>
+              <Spinner />
+              <span>Entrando...</span>
+            </>
+          ) : (
+            "Entrar"
+          )}
+        </button>
+      </form>
     </>
   );
 }

--- a/frontend/app/(protected)/core/page.tsx
+++ b/frontend/app/(protected)/core/page.tsx
@@ -1,11 +1,19 @@
-"use client";
+import { Database } from "lucide-react";
+import { ModulePlaceholder } from "@/app/components/layout/ModulePlaceholder";
 
 export default function CorePage() {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 flex items-center justify-center">
-      <h1 className="text-4xl font-bold text-zinc-700 dark:text-zinc-300">
-        Core — Módulo Central
-      </h1>
-    </div>
+    <ModulePlaceholder
+      shortName="Core"
+      fullName="Módulo Central"
+      Icon={Database}
+      description="Concentra dados base, usuários, perfis, territórios e configurações compartilhadas por todos os módulos do ecossistema PDHC III."
+      features={[
+        "Cadastro e gestão de usuários e perfis de acesso",
+        "Territórios e municípios atendidos pelo programa",
+        "Configurações gerais e parâmetros do sistema",
+        "Auditoria centralizada das ações dos usuários",
+      ]}
+    />
   );
 }

--- a/frontend/app/(protected)/dashboard/page.tsx
+++ b/frontend/app/(protected)/dashboard/page.tsx
@@ -54,15 +54,14 @@ export default function DashboardPage() {
             className="absolute -top-20 -right-20 h-64 w-64 rounded-full bg-white/10 blur-3xl"
           />
           <div className="relative">
-            <p className="text-sm text-white/80 uppercase tracking-wider font-medium">
-              Painel · Sprint 1
+            <p className="text-xs uppercase tracking-[0.2em] text-white/70 font-medium">
+              Painel inicial
             </p>
-            <h2 className="mt-2 text-2xl sm:text-3xl font-semibold leading-tight">
+            <h2 className="mt-3 text-2xl sm:text-3xl font-semibold leading-tight">
               {saudacao}, {primeiroNome}.
             </h2>
-            <p className="mt-2 text-sm text-white/80 max-w-md">
-              Seu painel está em construção. As métricas dos módulos aparecerão aqui
-              conforme forem entregues.
+            <p className="mt-3 text-sm text-white/80 max-w-md leading-relaxed">
+              Os indicadores dos módulos vão aparecer aqui conforme as funcionalidades forem liberadas.
             </p>
           </div>
         </section>

--- a/frontend/app/(protected)/sca/page.tsx
+++ b/frontend/app/(protected)/sca/page.tsx
@@ -1,11 +1,19 @@
-"use client";
+import { Smartphone } from "lucide-react";
+import { ModulePlaceholder } from "@/app/components/layout/ModulePlaceholder";
 
 export default function SCAPage() {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 flex items-center justify-center">
-      <h1 className="text-4xl font-bold text-blue-700 dark:text-blue-400">
-        SCA — Sistema de Coleta em Campo
-      </h1>
-    </div>
+    <ModulePlaceholder
+      shortName="SCA"
+      fullName="Sistema de Coleta em Campo"
+      Icon={Smartphone}
+      description="Aplicativo e ferramentas para coleta de dados em campo, com suporte a operação offline em áreas sem conectividade."
+      features={[
+        "Coleta offline com sincronização posterior",
+        "Captura de fotos, GPS e assinaturas digitais",
+        "Formulários publicados pelo SGF",
+        "Validação local e envio em lote ao retornar à internet",
+      ]}
+    />
   );
 }

--- a/frontend/app/(protected)/sgd/page.tsx
+++ b/frontend/app/(protected)/sgd/page.tsx
@@ -1,11 +1,19 @@
-"use client";
+import { FileText } from "lucide-react";
+import { ModulePlaceholder } from "@/app/components/layout/ModulePlaceholder";
 
 export default function SGDPage() {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 flex items-center justify-center">
-      <h1 className="text-4xl font-bold text-emerald-700 dark:text-emerald-400">
-        SGD — Sistema de Gestão de Demandas
-      </h1>
-    </div>
+    <ModulePlaceholder
+      shortName="SGD"
+      fullName="Sistema de Gestão de Demandas"
+      Icon={FileText}
+      description="Acompanhamento de pedidos, ordens e demandas geradas pelas equipes em campo e pelas instâncias gestoras do PDHC III."
+      features={[
+        "Cadastro e rastreamento de demandas por território",
+        "Workflow de aprovação por instância",
+        "Notificações de prazo e status",
+        "Integração com o SGE para conversão em atividades",
+      ]}
+    />
   );
 }

--- a/frontend/app/(protected)/sge/page.tsx
+++ b/frontend/app/(protected)/sge/page.tsx
@@ -1,11 +1,19 @@
-"use client";
+import { Calendar } from "lucide-react";
+import { ModulePlaceholder } from "@/app/components/layout/ModulePlaceholder";
 
 export default function SGEPage() {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 flex items-center justify-center">
-      <h1 className="text-4xl font-bold text-purple-700 dark:text-purple-400">
-        SGE — Sistema de Gestão de Eventos
-      </h1>
-    </div>
+    <ModulePlaceholder
+      shortName="SGE"
+      fullName="Sistema de Gestão de Eventos"
+      Icon={Calendar}
+      description="Calendário, planejamento e registro de eventos, oficinas e atividades realizadas nos territórios."
+      features={[
+        "Agenda integrada com módulos SGP e SGD",
+        "Inscrições e listas de presença por evento",
+        "Registro fotográfico e materiais entregues",
+        "Relatório de execução com indicadores de alcance",
+      ]}
+    />
   );
 }

--- a/frontend/app/(protected)/sgf/page.tsx
+++ b/frontend/app/(protected)/sgf/page.tsx
@@ -1,11 +1,19 @@
-"use client";
+import { Wallet } from "lucide-react";
+import { ModulePlaceholder } from "@/app/components/layout/ModulePlaceholder";
 
 export default function SGFPage() {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 flex items-center justify-center">
-      <h1 className="text-4xl font-bold text-amber-700 dark:text-amber-400">
-        SGF — Sistema de Gestão de Formulários
-      </h1>
-    </div>
+    <ModulePlaceholder
+      shortName="SGF"
+      fullName="Sistema de Gestão de Formulários"
+      Icon={Wallet}
+      description="Catálogo de formulários do programa, com versões, regras de preenchimento e exportações para coleta em campo."
+      features={[
+        "Editor visual de formulários com perguntas e validações",
+        "Versionamento e histórico de alterações por instrumento",
+        "Publicação para uso pelo módulo SCA em campo",
+        "Exportação consolidada das respostas recebidas",
+      ]}
+    />
   );
 }

--- a/frontend/app/(protected)/sgp/page.tsx
+++ b/frontend/app/(protected)/sgp/page.tsx
@@ -1,11 +1,19 @@
-"use client";
+import { Users } from "lucide-react";
+import { ModulePlaceholder } from "@/app/components/layout/ModulePlaceholder";
 
 export default function SGPPage() {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 flex items-center justify-center">
-      <h1 className="text-4xl font-bold text-rose-700 dark:text-rose-400">
-        SGP — Sistema de Gestão de Projetos
-      </h1>
-    </div>
+    <ModulePlaceholder
+      shortName="SGP"
+      fullName="Sistema de Gestão de Projetos"
+      Icon={Users}
+      description="Planejamento, execução e acompanhamento de projetos territoriais articulados com a agricultura familiar."
+      features={[
+        "Cadastro de projetos com vínculo a territórios e cadeias produtivas",
+        "Cronograma físico e financeiro por etapa",
+        "Acompanhamento de beneficiários e famílias atendidas",
+        "Indicadores e relatórios consolidados de execução",
+      ]}
+    />
   );
 }

--- a/frontend/app/(protected)/sgs/page.tsx
+++ b/frontend/app/(protected)/sgs/page.tsx
@@ -1,11 +1,19 @@
-"use client";
+import { Heart } from "lucide-react";
+import { ModulePlaceholder } from "@/app/components/layout/ModulePlaceholder";
 
 export default function SGSPage() {
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 flex items-center justify-center">
-      <h1 className="text-4xl font-bold text-cyan-700 dark:text-cyan-400">
-        SGS — Sistema de Gestão de Seleções
-      </h1>
-    </div>
+    <ModulePlaceholder
+      shortName="SGS"
+      fullName="Sistema de Gestão de Seleções"
+      Icon={Heart}
+      description="Processos seletivos de famílias, organizações e parceiros para participação nas frentes do programa."
+      features={[
+        "Editais e chamadas com critérios configuráveis",
+        "Inscrições e análise documental com pareceres",
+        "Classificação e resultado por etapa",
+        "Recursos e comunicação com inscritos",
+      ]}
+    />
   );
 }

--- a/frontend/app/components/layout/AppShell.tsx
+++ b/frontend/app/components/layout/AppShell.tsx
@@ -9,7 +9,7 @@ type AppShellProps = {
 
 export function AppShell({ sidebar, children }: AppShellProps) {
   return (
-    <div className="min-h-screen bg-bg">
+    <div className="min-h-screen">
       <SkipLinks />
 
       <aside className="hidden md:flex fixed top-0 left-0 h-screen w-[var(--sidebar-width)] flex-col z-10 transition-[width] duration-200 shadow-[1px_0_0_0_color-mix(in_srgb,var(--color-border)_50%,transparent)]">
@@ -29,7 +29,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
         </main>
         <footer className="px-6 py-4">
           <p className="text-micro font-mono text-text-muted/60 text-center">
-            Ecossistema PDHC III · Sprint 1
+            Ecossistema PDHC III
           </p>
         </footer>
       </div>

--- a/frontend/app/components/layout/AppShell.tsx
+++ b/frontend/app/components/layout/AppShell.tsx
@@ -12,7 +12,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
     <div className="min-h-screen bg-bg">
       <SkipLinks />
 
-      <aside className="hidden md:flex fixed top-0 left-0 h-screen w-60 bg-surface border-r border-border flex-col z-10">
+      <aside className="hidden md:flex fixed top-0 left-0 h-screen w-[var(--sidebar-width)] flex-col z-10 transition-[width] duration-200 shadow-[1px_0_0_0_color-mix(in_srgb,var(--color-border)_50%,transparent)]">
         <nav
           id="main-nav"
           aria-label="Navegação principal"
@@ -22,13 +22,13 @@ export function AppShell({ sidebar, children }: AppShellProps) {
         </nav>
       </aside>
 
-      <div className="md:ml-60 flex flex-col min-h-screen">
+      <div className="md:ml-[var(--sidebar-width)] flex flex-col min-h-screen transition-[margin-left] duration-200">
         <Header />
         <main id="main-content" className="flex-1 p-6 pb-20 md:pb-6">
           {children}
         </main>
-        <footer className="border-t border-border bg-surface px-6 py-3">
-          <p className="text-micro font-mono text-text-muted text-center">
+        <footer className="px-6 py-4">
+          <p className="text-micro font-mono text-text-muted/60 text-center">
             Ecossistema PDHC III · Sprint 1
           </p>
         </footer>
@@ -36,7 +36,7 @@ export function AppShell({ sidebar, children }: AppShellProps) {
 
       <nav
         aria-label="Navegação principal (móvel)"
-        className="md:hidden fixed bottom-0 left-0 right-0 h-14 bg-surface border-t border-border flex items-center justify-center z-10"
+        className="md:hidden fixed bottom-0 left-0 right-0 h-14 bg-surface/80 backdrop-blur-md flex items-center justify-center z-10 shadow-[0_-1px_0_0_color-mix(in_srgb,var(--color-border)_60%,transparent)]"
       >
         <p className="text-micro font-mono text-text-muted">
           Bottom nav placeholder · sprint do SCA

--- a/frontend/app/components/layout/Header.tsx
+++ b/frontend/app/components/layout/Header.tsx
@@ -1,79 +1,9 @@
-"use client";
-
-import { useState } from "react";
-import { useSession } from "next-auth/react";
-import { logout } from "@/app/lib/api";
-import Spinner from "@/app/components/ui/Spinner";
 import { PAGE_HEADER_SLOT_ID } from "./PageHeader";
-
-function getIniciais(nome: string): string {
-  const partes = nome.split(" ").filter(Boolean);
-  if (partes.length === 0) return "?";
-  if (partes.length === 1) return partes[0][0]?.toUpperCase() ?? "?";
-  return (
-    (partes[0][0] ?? "") + (partes[partes.length - 1][0] ?? "")
-  ).toUpperCase();
-}
-
-function UserMenu() {
-  const { data: session } = useSession();
-  const [leaving, setLeaving] = useState(false);
-
-  async function handleLogout() {
-    setLeaving(true);
-    await logout();
-  }
-
-  if (!session?.user) return null;
-
-  const { nome_completo, foto_url } = session.user;
-  const nome = nome_completo || "Usuário";
-  const iniciais = getIniciais(nome);
-
-  return (
-    <div className="flex items-center gap-3">
-      {foto_url ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={foto_url}
-          alt=""
-          className="h-8 w-8 rounded-full object-cover border border-border shrink-0"
-        />
-      ) : (
-        <div
-          aria-hidden="true"
-          className="h-8 w-8 rounded-full bg-primary text-surface text-xs font-medium flex items-center justify-center shrink-0"
-        >
-          {iniciais}
-        </div>
-      )}
-      <span className="hidden sm:block text-sm font-medium text-text truncate max-w-[180px]">
-        {nome}
-      </span>
-      <button
-        type="button"
-        disabled={leaving}
-        onClick={handleLogout}
-        className="h-9 px-3 rounded-md border border-border bg-surface text-sm font-medium text-text hover:bg-surface-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2"
-      >
-        {leaving ? (
-          <>
-            <Spinner />
-            <span>Saindo...</span>
-          </>
-        ) : (
-          <span>Sair</span>
-        )}
-      </button>
-    </div>
-  );
-}
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-20 h-14 bg-surface border-b border-border flex items-center justify-between gap-4 px-6">
+    <header className="sticky top-0 z-20 h-14 bg-surface flex items-center px-6 shadow-[0_1px_0_0_color-mix(in_srgb,var(--color-border)_60%,transparent)]">
       <div id={PAGE_HEADER_SLOT_ID} className="flex-1 min-w-0" />
-      <UserMenu />
     </header>
   );
 }

--- a/frontend/app/components/layout/ModulePlaceholder.tsx
+++ b/frontend/app/components/layout/ModulePlaceholder.tsx
@@ -1,0 +1,95 @@
+import type { LucideIcon } from "lucide-react";
+import { Sparkles } from "lucide-react";
+import { PageHeader } from "./PageHeader";
+
+type ModulePlaceholderProps = {
+  shortName: string;
+  fullName: string;
+  description: string;
+  Icon: LucideIcon;
+  features?: string[];
+};
+
+export function ModulePlaceholder({
+  shortName,
+  fullName,
+  description,
+  Icon,
+  features,
+}: ModulePlaceholderProps) {
+  return (
+    <>
+      <PageHeader>
+        <div className="flex items-baseline gap-2 min-w-0">
+          <h1 className="text-base font-semibold text-text truncate">
+            {shortName}
+          </h1>
+          <span className="hidden sm:inline text-xs text-text-muted truncate">
+            {fullName}
+          </span>
+        </div>
+      </PageHeader>
+
+      <div className="max-w-2xl mx-auto pt-8 sm:pt-12">
+        <div className="relative">
+          <div
+            aria-hidden="true"
+            className="absolute -top-12 -left-12 h-64 w-64 rounded-full bg-gradient-to-br from-primary/10 to-transparent blur-2xl"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute -top-8 right-0 h-48 w-48 rounded-full bg-gradient-to-tl from-accent-ocre/10 to-transparent blur-2xl"
+          />
+
+          <div className="relative">
+            <div className="flex items-center justify-center h-16 w-16 rounded-2xl bg-gradient-to-br from-primary to-secondary text-surface shadow-lg shadow-primary/20">
+              <Icon className="h-7 w-7" aria-hidden="true" strokeWidth={1.75} />
+            </div>
+
+            <div className="mt-10">
+              <span className="inline-flex items-center gap-2 px-2.5 py-1 rounded-full bg-warning-bg border border-warning-text/20">
+                <Sparkles
+                  className="h-3 w-3 text-warning-text"
+                  aria-hidden="true"
+                />
+                <span className="text-[10px] font-medium uppercase tracking-wider text-warning-text">
+                  Em desenvolvimento
+                </span>
+              </span>
+            </div>
+
+            <h2 className="mt-4 text-3xl sm:text-4xl font-semibold leading-tight text-text tracking-tight">
+              {fullName}
+            </h2>
+
+            <p className="mt-4 text-base text-text-muted leading-relaxed max-w-xl">
+              {description}
+            </p>
+          </div>
+        </div>
+
+        {features && features.length > 0 && (
+          <div className="mt-12 pt-8 border-t border-border">
+            <p className="text-[10px] font-medium uppercase tracking-[0.2em] text-text-muted mb-4">
+              O que vem por aí
+            </p>
+            <ul className="grid sm:grid-cols-2 gap-x-6 gap-y-3">
+              {features.map((f) => (
+                <li
+                  key={f}
+                  className="flex items-start gap-2.5 text-sm text-text leading-relaxed"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="mt-1.5 h-1 w-1 rounded-full bg-primary shrink-0"
+                  />
+                  <span>{f}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/app/components/layout/Sidebar.tsx
+++ b/frontend/app/components/layout/Sidebar.tsx
@@ -1,33 +1,310 @@
-import Link from "next/link";
-import { BrandMark } from "@/app/components/icons";
+"use client";
 
-const NAV_ITEMS = [
-  { href: "/dashboard", label: "Dashboard" },
+import { KeyboardEvent, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
+import {
+  Calendar,
+  ChevronLeft,
+  ChevronRight,
+  Database,
+  FileText,
+  Heart,
+  LayoutDashboard,
+  LogOut,
+  SlidersHorizontal,
+  Smartphone,
+  Users,
+  Wallet,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { BrandMark } from "@/app/components/icons";
+import Spinner from "@/app/components/ui/Spinner";
+import { logout } from "@/app/lib/api";
+
+type ModuleItem = {
+  href: string;
+  label: string;
+  Icon: LucideIcon;
+  badge?: number;
+};
+
+const STORAGE_KEY = "sidebar.collapsed";
+
+const DASHBOARD: ModuleItem = {
+  href: "/dashboard",
+  label: "Dashboard",
+  Icon: LayoutDashboard,
+};
+
+// Badges mock: substituir por /api/v1/notifications/me/unread-count/ em sprint futura
+const MODULES: ModuleItem[] = [
+  { href: "/core", label: "Core", Icon: Database },
+  { href: "/sgp", label: "SGP", Icon: Users, badge: 3 },
+  { href: "/sgf", label: "SGF", Icon: Wallet },
+  { href: "/sgd", label: "SGD", Icon: FileText, badge: 1 },
+  { href: "/sgs", label: "SGS", Icon: Heart },
+  { href: "/sge", label: "SGE", Icon: Calendar, badge: 2 },
+  { href: "/sca", label: "SCA", Icon: Smartphone },
 ];
 
-export function Sidebar() {
+function getIniciais(nome: string): string {
+  const partes = nome.split(" ").filter(Boolean);
+  if (partes.length === 0) return "?";
+  if (partes.length === 1) return partes[0][0]?.toUpperCase() ?? "?";
   return (
-    <div className="flex flex-col h-full">
-      <div className="h-14 px-4 flex items-center border-b border-border shrink-0">
-        <BrandMark />
+    (partes[0][0] ?? "") + (partes[partes.length - 1][0] ?? "")
+  ).toUpperCase();
+}
+
+function isActive(pathname: string | null, href: string): boolean {
+  if (!pathname) return false;
+  if (pathname === href) return true;
+  return pathname.startsWith(href + "/");
+}
+
+type SidebarItemProps = {
+  item: ModuleItem;
+  active: boolean;
+  collapsed: boolean;
+};
+
+function SidebarItem({ item, active, collapsed }: SidebarItemProps) {
+  const { Icon, label, href, badge } = item;
+  const base =
+    "group relative flex items-center gap-3 h-10 rounded-md text-sm border-l-[3px] transition-colors duration-150";
+  const layout = collapsed ? "px-2 justify-center" : "pl-3 pr-3";
+  const state = active
+    ? "border-primary bg-success-bg text-success-text font-medium"
+    : "border-transparent text-text-muted hover:bg-surface-muted hover:text-text";
+  const badgeClass = collapsed
+    ? "absolute top-0.5 right-0.5 min-w-[16px] h-[16px] px-1 rounded-full text-[10px] font-medium bg-primary text-surface flex items-center justify-center"
+    : "ml-auto min-w-[20px] h-[20px] px-1.5 rounded-full text-[10px] font-medium bg-primary text-surface flex items-center justify-center";
+
+  return (
+    <Link
+      href={href}
+      title={collapsed ? label : undefined}
+      aria-current={active ? "page" : undefined}
+      className={`${base} ${layout} ${state}`}
+    >
+      <Icon
+        className="h-[18px] w-[18px] shrink-0 transition-transform group-hover:scale-105"
+        strokeWidth={active ? 2 : 1.75}
+      />
+      {!collapsed && <span className="flex-1 truncate">{label}</span>}
+      {badge && badge > 0 && <span className={badgeClass}>{badge}</span>}
+    </Link>
+  );
+}
+
+type UserMenuProps = {
+  collapsed: boolean;
+};
+
+function UserMenu({ collapsed }: UserMenuProps) {
+  const { data: session } = useSession();
+  const [leaving, setLeaving] = useState(false);
+
+  async function handleLogout() {
+    setLeaving(true);
+    await logout();
+  }
+
+  if (!session?.user) return null;
+
+  const { nome_completo, foto_url, perfis } = session.user;
+  const nome = nome_completo || "Usuário";
+  const iniciais = getIniciais(nome);
+  const perfilPrincipal =
+    perfis && perfis.length > 0 ? perfis[0].nome : "Sem perfil";
+
+  const avatar = foto_url ? (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={foto_url}
+      alt=""
+      className="h-9 w-9 rounded-full object-cover ring-2 ring-surface shadow-md shrink-0"
+    />
+  ) : (
+    <div
+      aria-hidden="true"
+      className="h-9 w-9 rounded-full bg-gradient-to-br from-primary to-secondary text-surface text-xs font-medium flex items-center justify-center shadow-md shadow-primary/20 shrink-0"
+    >
+      {iniciais}
+    </div>
+  );
+
+  if (collapsed) {
+    return (
+      <div className="px-2 py-3 flex flex-col items-center gap-2.5">
+        <span title={`${nome} · ${perfilPrincipal}`}>{avatar}</span>
+        <Link
+          href="/preferencias"
+          title="Preferências"
+          className="p-2 rounded-lg text-text-muted hover:bg-surface-muted/60 hover:text-text transition-colors"
+        >
+          <SlidersHorizontal className="h-4 w-4" />
+        </Link>
+        <button
+          type="button"
+          onClick={handleLogout}
+          disabled={leaving}
+          title="Sair"
+          className="p-2 rounded-lg text-text-muted hover:bg-error-bg/60 hover:text-error-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {leaving ? (
+            <Spinner className="h-4 w-4 animate-spin" />
+          ) : (
+            <LogOut className="h-4 w-4" />
+          )}
+        </button>
       </div>
-      <ul className="flex-1 p-2 space-y-1">
-        {NAV_ITEMS.map((item) => (
-          <li key={item.href}>
-            <Link
-              href={item.href}
-              className="block px-3 py-2 rounded-md text-sm text-text hover:bg-surface-muted transition-colors"
+    );
+  }
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="flex items-center gap-3 min-w-0 px-1">
+        {avatar}
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-text truncate leading-tight">
+            {nome}
+          </p>
+          <p className="text-xs text-text-muted truncate mt-0.5">
+            {perfilPrincipal}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <Link
+          href="/preferencias"
+          className="flex-1 inline-flex items-center justify-center gap-1.5 h-8 px-2 rounded-lg text-xs text-text-muted hover:bg-surface-muted/60 hover:text-text transition-colors"
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          <span>Preferências</span>
+        </Link>
+        <button
+          type="button"
+          onClick={handleLogout}
+          disabled={leaving}
+          className="inline-flex items-center justify-center gap-1.5 h-8 px-2.5 rounded-lg text-xs text-text-muted hover:bg-error-bg/60 hover:text-error-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {leaving ? (
+            <Spinner className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <LogOut className="h-3.5 w-3.5" />
+          )}
+          <span>{leaving ? "Saindo" : "Sair"}</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function Sidebar() {
+  const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
+  const listRef = useRef<HTMLUListElement | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY) === "true";
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCollapsed(saved);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(collapsed));
+    document.documentElement.style.setProperty(
+      "--sidebar-width",
+      collapsed ? "4rem" : "15rem",
+    );
+  }, [collapsed]);
+
+  function onListKeyDown(e: KeyboardEvent<HTMLUListElement>) {
+    if (!listRef.current) return;
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    const links = Array.from(
+      listRef.current.querySelectorAll<HTMLAnchorElement>("a"),
+    );
+    const currentIndex = links.findIndex((l) => l === document.activeElement);
+    if (currentIndex === -1) return;
+    e.preventDefault();
+    const nextIndex =
+      e.key === "ArrowDown"
+        ? Math.min(currentIndex + 1, links.length - 1)
+        : Math.max(currentIndex - 1, 0);
+    links[nextIndex]?.focus();
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-surface">
+      <div
+        className={`h-14 flex items-center shrink-0 shadow-[0_1px_0_0_color-mix(in_srgb,var(--color-border)_60%,transparent)] ${
+          collapsed ? "px-2 justify-center" : "px-4"
+        }`}
+      >
+        {collapsed ? (
+          <button
+            type="button"
+            onClick={() => setCollapsed(false)}
+            title="Expandir sidebar"
+            aria-label="Expandir sidebar"
+            className="p-2 rounded-lg hover:bg-surface-muted/60 text-text-muted hover:text-text transition-colors"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        ) : (
+          <>
+            <BrandMark />
+            <button
+              type="button"
+              onClick={() => setCollapsed(true)}
+              title="Recolher sidebar"
+              aria-label="Recolher sidebar"
+              className="ml-auto p-1.5 rounded-lg hover:bg-surface-muted/60 text-text-muted hover:text-text transition-colors"
             >
-              {item.label}
-            </Link>
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+          </>
+        )}
+      </div>
+
+      <ul
+        ref={listRef}
+        onKeyDown={onListKeyDown}
+        className="flex-1 overflow-y-auto py-3 px-2 space-y-0.5"
+      >
+        <li>
+          <SidebarItem
+            item={DASHBOARD}
+            active={isActive(pathname, DASHBOARD.href)}
+            collapsed={collapsed}
+          />
+        </li>
+        {collapsed ? (
+          <li aria-hidden="true" className="mx-3 my-3 h-px bg-border/40" />
+        ) : (
+          <li
+            aria-hidden="true"
+            className="px-3 pt-5 pb-1.5 text-[10px] font-medium uppercase tracking-[0.18em] text-text-muted/70"
+          >
+            Módulos
+          </li>
+        )}
+        {MODULES.map((m) => (
+          <li key={m.href}>
+            <SidebarItem
+              item={m}
+              active={isActive(pathname, m.href)}
+              collapsed={collapsed}
+            />
           </li>
         ))}
       </ul>
-      <div className="p-3 border-t border-border">
-        <p className="text-micro font-mono text-text-muted text-center">
-          Sidebar placeholder · FE-04
-        </p>
-      </div>
+
+      <UserMenu collapsed={collapsed} />
     </div>
   );
 }

--- a/frontend/app/components/layout/Sidebar.tsx
+++ b/frontend/app/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import type { LucideIcon } from "lucide-react";
 import { BrandMark } from "@/app/components/icons";
 import Spinner from "@/app/components/ui/Spinner";
 import { logout } from "@/app/lib/api";
+import { ThemeToggle } from "./ThemeToggle";
 
 type ModuleItem = {
   href: string;
@@ -143,7 +144,7 @@ function UserMenu({ collapsed }: UserMenuProps) {
         <Link
           href="/preferencias"
           title="Preferências"
-          className="p-2 rounded-lg text-text-muted hover:bg-surface-muted/60 hover:text-text transition-colors"
+          className="p-2 rounded-lg text-text-muted hover:bg-surface-muted hover:text-text transition-colors"
         >
           <SlidersHorizontal className="h-4 w-4" />
         </Link>
@@ -152,7 +153,7 @@ function UserMenu({ collapsed }: UserMenuProps) {
           onClick={handleLogout}
           disabled={leaving}
           title="Sair"
-          className="p-2 rounded-lg text-text-muted hover:bg-error-bg/60 hover:text-error-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="p-2 rounded-lg text-text-muted hover:bg-error-bg hover:text-error-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {leaving ? (
             <Spinner className="h-4 w-4 animate-spin" />
@@ -177,10 +178,10 @@ function UserMenu({ collapsed }: UserMenuProps) {
           </p>
         </div>
       </div>
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1">
         <Link
           href="/preferencias"
-          className="flex-1 inline-flex items-center justify-center gap-1.5 h-8 px-2 rounded-lg text-xs text-text-muted hover:bg-surface-muted/60 hover:text-text transition-colors"
+          className="flex-1 inline-flex items-center justify-center gap-1.5 h-8 px-2 rounded-lg text-xs text-text-muted hover:bg-surface-muted hover:text-text transition-colors"
         >
           <SlidersHorizontal className="h-3.5 w-3.5" />
           <span>Preferências</span>
@@ -189,7 +190,7 @@ function UserMenu({ collapsed }: UserMenuProps) {
           type="button"
           onClick={handleLogout}
           disabled={leaving}
-          className="inline-flex items-center justify-center gap-1.5 h-8 px-2.5 rounded-lg text-xs text-text-muted hover:bg-error-bg/60 hover:text-error-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="inline-flex items-center justify-center gap-1.5 h-8 px-2.5 rounded-lg text-xs text-text-muted hover:bg-error-bg hover:text-error-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {leaving ? (
             <Spinner className="h-3.5 w-3.5 animate-spin" />
@@ -303,6 +304,16 @@ export function Sidebar() {
           </li>
         ))}
       </ul>
+
+      <div
+        className={`shrink-0 ${
+          collapsed
+            ? "px-2 py-2 flex justify-center"
+            : "px-3 py-2 flex justify-end"
+        }`}
+      >
+        <ThemeToggle collapsed={collapsed} />
+      </div>
 
       <UserMenu collapsed={collapsed} />
     </div>

--- a/frontend/app/components/layout/ThemeToggle.tsx
+++ b/frontend/app/components/layout/ThemeToggle.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Monitor, Moon, Sun } from "lucide-react";
+
+type Theme = "system" | "light" | "dark";
+
+const STORAGE_KEY = "theme";
+const CYCLE: Theme[] = ["system", "light", "dark"];
+
+function readSavedTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved === "light" || saved === "dark") return saved;
+  return "system";
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  if (theme === "system") {
+    root.removeAttribute("data-theme");
+    localStorage.removeItem(STORAGE_KEY);
+  } else {
+    root.setAttribute("data-theme", theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }
+}
+
+const META: Record<Theme, { Icon: typeof Sun; label: string }> = {
+  system: { Icon: Monitor, label: "Tema do sistema" },
+  light: { Icon: Sun, label: "Tema claro" },
+  dark: { Icon: Moon, label: "Tema escuro" },
+};
+
+type ThemeToggleProps = {
+  collapsed: boolean;
+};
+
+export function ThemeToggle({ collapsed }: ThemeToggleProps) {
+  const [theme, setTheme] = useState<Theme>("system");
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTheme(readSavedTheme());
+  }, []);
+
+  function cycle() {
+    const next = CYCLE[(CYCLE.indexOf(theme) + 1) % CYCLE.length];
+    setTheme(next);
+    applyTheme(next);
+  }
+
+  const { Icon, label } = META[theme];
+
+  const buttonClass = collapsed
+    ? "p-2 rounded-lg text-text-muted hover:bg-surface-muted hover:text-text transition-colors"
+    : "inline-flex items-center justify-center h-8 w-8 rounded-lg text-text-muted hover:bg-surface-muted hover:text-text transition-colors";
+
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      title={label}
+      aria-label={label}
+      className={buttonClass}
+    >
+      <Icon className={collapsed ? "h-4 w-4" : "h-3.5 w-3.5"} />
+    </button>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -77,6 +77,10 @@
   --space-6: 24px;
   --space-7: 28px;
   --space-8: 32px;
+
+  /* ── Layout ──────────────────────────────────────── */
+  /* Largura da Sidebar (alternada entre 240px expandida e 64px recolhida em runtime) */
+  --sidebar-width: 15rem;
 }
 
 /* @theme inline: fontes (precisam dos vars do Next.js) */

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -91,17 +91,22 @@
     var(--font-jetbrains-mono), ui-monospace, "Cascadia Code", monospace;
 }
 
-/* Dark mode: sobrescreve as CSS vars geradas pelo @theme acima */
+/*
+  Dark mode: sobrescreve as CSS vars geradas pelo @theme acima.
+  Aplicado em dois cenarios:
+  1. SO em dark mode E usuario nao forcou "light" via data-theme
+  2. Usuario forcou "dark" via data-theme
+  Mantemos as duas regras separadas (mesmo conteudo) para que o
+  override manual sempre vença o sistema operacional.
+*/
 @media (prefers-color-scheme: dark) {
-  :root {
-    /* Paleta principal */
+  :root:not([data-theme="light"]) {
     --color-primary: #4a9c6d;
     --color-secondary: #5baf7e;
     --color-accent-sage: #6a9e79;
     --color-accent-terracota: #d4805a;
     --color-accent-ocre: #e0b356;
 
-    /* Superfícies e neutros */
     --color-bg: #1a1a18;
     --color-surface: #252523;
     --color-surface-muted: #2e2e2b;
@@ -110,7 +115,6 @@
     --color-text: #e8e6e0;
     --color-text-muted: #9e9b93;
 
-    /* Semânticas */
     --color-success-bg: #1a3325;
     --color-success-text: #4a9c6d;
     --color-warning-bg: #2e2200;
@@ -122,14 +126,65 @@
     --color-neutral-bg: #2a2a27;
     --color-neutral-text: #9e9b93;
 
-    /* Aliases */
     --color-error: #ef5350;
     --color-success: #4a9c6d;
   }
 }
 
+:root[data-theme="dark"] {
+  --color-primary: #4a9c6d;
+  --color-secondary: #5baf7e;
+  --color-accent-sage: #6a9e79;
+  --color-accent-terracota: #d4805a;
+  --color-accent-ocre: #e0b356;
+
+  --color-bg: #1a1a18;
+  --color-surface: #252523;
+  --color-surface-muted: #2e2e2b;
+  --color-surface-warm: #2a2520;
+  --color-border: #3a3a37;
+  --color-text: #e8e6e0;
+  --color-text-muted: #9e9b93;
+
+  --color-success-bg: #1a3325;
+  --color-success-text: #4a9c6d;
+  --color-warning-bg: #2e2200;
+  --color-warning-text: #d4a044;
+  --color-error-bg: #3b1515;
+  --color-error-text: #ef5350;
+  --color-info-bg: #0d2a4d;
+  --color-info-text: #64b5f6;
+  --color-neutral-bg: #2a2a27;
+  --color-neutral-text: #9e9b93;
+
+  --color-error: #ef5350;
+  --color-success: #4a9c6d;
+}
+
 body {
   background-color: var(--color-bg);
+  background-image:
+    radial-gradient(
+      ellipse 90% 70% at 100% 0%,
+      color-mix(in srgb, var(--color-primary) 18%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 80% 60% at 0% 100%,
+      color-mix(in srgb, var(--color-accent-ocre) 14%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 60% 50% at 50% 100%,
+      color-mix(in srgb, var(--color-accent-sage) 10%, transparent),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 50% 40% at 0% 0%,
+      color-mix(in srgb, var(--color-secondary) 8%, transparent),
+      transparent 60%
+    );
+  background-attachment: fixed;
   color: var(--color-text);
   font-family: var(--font-sans);
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -27,10 +27,21 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${inter.variable} ${jetbrainsMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
+      <head>
+        <script
+          // Aplica a preferência de tema salva ANTES do paint, evitando flash
+          // entre claro/escuro durante a hidratação. Quando não houver
+          // preferência, o navegador segue prefers-color-scheme do sistema.
+          dangerouslySetInnerHTML={{
+            __html: `try{var t=localStorage.getItem('theme');if(t==='light'||t==='dark'){document.documentElement.setAttribute('data-theme',t);}}catch(_){}`,
+          }}
+        />
+      </head>
       <body className="min-h-full flex flex-col">
-          <SessionProvider>{children}</SessionProvider>
-        </body>
+        <SessionProvider>{children}</SessionProvider>
+      </body>
     </html>
   );
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^1.16.0",
         "next": "16.2.4",
         "next-auth": "^5.0.0-beta.31",
         "react": "19.2.4",
@@ -5012,6 +5013,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "lucide-react": "^1.16.0",
     "next": "16.2.4",
     "next-auth": "^5.0.0-beta.31",
     "react": "19.2.4",


### PR DESCRIPTION
● ## Contexto

  Implementa a Sidebar definitiva pedida pela issue 51 (substituindo o
  placeholder do issue 50) e, no mesmo PR, traz uma rodada de polimento
  visual pra deixar a base mais coerente, com vida e adaptável ao tema do
  usuário.

  ## Mudanças

  ### Sidebar (`components/layout/Sidebar.tsx`)
  - Dashboard no topo + 7 módulos hardcoded (Core, SGP, SGF, SGD, SGS, SGE,
  SCA) com ícones do `lucide-react`.
  - Item ativo: borda esquerda 3px `primary`, fundo `success-bg`, texto
  `success-text`, font-medium. Detectado via `usePathname()`.
  - Item inativo: `text-muted` + hover `bg-surface-muted`.
  - Badges mock em SGP (3), SGD (1), SGE (2); conexão real com
  `/api/v1/notifications/me/unread-count/` fica para sprint futura.
  - Toggle recolher/expandir 240↔64px persistido em `localStorage` chave
  `sidebar.collapsed`. Modo recolhido mostra só ícones com tooltip nativo
  (atributo `title`); badge continua visível.
  - Rodapé com avatar, nome, perfil principal (via `useSession` do NextAuth
  até o AuthContext da #23 existir), link `/preferencias` e botão de logout
  que chama `/api/v1/auth/logout/` e redireciona para `/login`.
  - Navegação por teclado: Tab natural; setas ↑/↓ navegam entre os itens.
  - `lucide-react ^1.16.0` adicionado às dependências.

  ### AppShell, Header
  - AppShell reage ao colapso da Sidebar via `var(--sidebar-width)` (default
   15rem em `globals.css`, atualizado em runtime pela Sidebar).
  - Header perde o UserMenu (foi pro rodapé da Sidebar) e fica só com o slot
   do PageHeader.
  - Header e topo da Sidebar compartilham `bg-surface` + sombra inferior de
  1px formando uma barra horizontal contínua, sem "quebra" visual entre os
  dois.
  - AppShell ganha landmark `<footer>` (vinha pendente do critério ARIA do
  issue 50).

  ### Pages de módulo
  - Cria `components/layout/ModulePlaceholder` reutilizável: hero com ícone
  em quadrado de gradient, badge "Em desenvolvimento" + lista "O que vem por
   aí".
  - Reescreve as 7 pages (`core`, `sgp`, `sgf`, `sgd`, `sgs`, `sge`, `sca`)
  consumindo o componente, cada uma com conteúdo próprio.
  - Remove `min-h-screen` e bg duplicado dessas pages que estavam
  sobrescrevendo o AppShell.
  - Dashboard hero perde "Painel · Sprint 1", texto reescrito.

  ### Login (`(auth)/layout.tsx` + `(auth)/login/page.tsx`)
  - Painel esquerdo agora com fundo verde profundo (`#0d2e1d`) + 2 glows
  radiais + textura de pontos quase imperceptível. Headline grande em duas
  linhas, mais respiro.
  - Painel direito sem card branco. Form respira direto sobre a superfície.
  Inputs com altura 48px, focus com ring em color-mix. Link "Esqueci minha
  senha" alinhado à direita acima do campo de senha.
  - Botão submit com gradient `primary → secondary` e shadow colorida no
  hover.

  ### Tema claro/escuro com toggle
  - `globals.css`: dark mode dispara em dois cenários: (1)
  `prefers-color-scheme: dark` quando não há `data-theme="light"`; (2)
  `data-theme="dark"` explícito (override manual sempre vence o SO).
  - `app/layout.tsx`: script síncrono no `<head>` lê localStorage e aplica
  `data-theme` antes do paint, evitando flash entre temas durante a
  hidratação.
  - `components/layout/ThemeToggle.tsx`: botão icon-only no rodapé da
  Sidebar (sempre visível, mesmo sem sessão) que cicla Sistema → Claro →
  Escuro. Persiste em `localStorage` chave `theme`.

  ## Critérios da issue 51

  | Item | Estado |
  |---|---|
  | Sidebar com 7 módulos | OK |
  | Item ativo: borda 3px primary + bg success-bg + texto verde escuro | OK
  |
  | Item inativo: texto cinza, hover bg-surface-muted | OK |
  | Badge de pendências mock | OK |
  | Modo recolhido 64px + localStorage `sidebar.collapsed` + tooltip | OK |
  | Badge visível no recolhido | OK |
  | Rodapé com avatar + nome + perfil + /preferencias + logout | OK |
  | Ícone `lucide-react` + label + badge opcional | OK |
  | Avatar puxa nome e perfil do AuthContext (#23) | Diferida (usa
  `useSession` do NextAuth enquanto #23 não existir) |
  | Logout em `/api/v1/auth/logout/` + redirect `/login` | OK |
  | Item ativo via `usePathname()` + transição suave | OK |
  | Tab + setas ↑↓ | OK |

  ## Extras (fora do escopo estrito da issue)

  - Pages dos módulos com placeholder visual padronizado
  - Login modernizado
  - Toggle de tema claro/escuro
  - Fundo com gradient pra dar vida ao tema claro

  ## Test plan

  - [ ] Sidebar em 1280px: 240px, scroll fixa, item ativo destaca, badges
  aparecem
  - [ ] Toggle recolher: 64px, só ícones, tooltip ao hover, badge continua
  visível
  - [ ] Recarregar página: preferência da sidebar (recolhida/expandida)
  mantida
  - [ ] Tab navega entre itens; setas ↑↓ funcionam dentro da lista
  - [ ] Botão logout chama backend e redireciona pra /login
  - [ ] /core, /sgp etc. mostram placeholder com "Em desenvolvimento"
  - [ ] /login: gradient verde no painel esquerdo, form limpo à direita
  - [ ] Toggle de tema no rodapé da Sidebar: cicla Monitor → Sol → Lua;
  preferência mantida ao recarregar
  - [ ] Mudar OS pra dark/light: app respeita se toggle estiver em
  "Sistema", e ignora se estiver em "Claro" ou "Escuro"
  - [ ] Fundo: gradientes sutis visíveis em ambos os temas