### PR TITLE
Issue 54 - NotificationBell no Header (FE-03)

### DIFF
--- a/frontend/app/(protected)/notificacoes/page.tsx
+++ b/frontend/app/(protected)/notificacoes/page.tsx
@@ -1,0 +1,25 @@
+import { Bell } from "lucide-react";
+import { PageHeader } from "@/app/components/layout/PageHeader";
+
+export default function NotificacoesPage() {
+  return (
+    <>
+      <PageHeader>
+        <h1 className="text-base font-semibold text-text truncate">Notificações</h1>
+      </PageHeader>
+
+      <div className="mx-auto flex max-w-2xl flex-col items-center gap-4 rounded-lg border border-border bg-surface px-6 py-16 text-center">
+        <span className="text-text-muted">
+          <Bell className="h-10 w-10" aria-hidden="true" />
+        </span>
+        <h2 className="text-lg font-semibold text-text">
+          Central de notificações
+        </h2>
+        <p className="max-w-md text-sm leading-relaxed text-text-muted">
+          A listagem completa das suas notificações vai aparecer aqui em breve.
+          Por enquanto, consulte as mais recentes pelo sino no topo da página.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/components/layout/Header.tsx
+++ b/frontend/app/components/layout/Header.tsx
@@ -1,9 +1,11 @@
 import { PAGE_HEADER_SLOT_ID } from "./PageHeader";
+import { NotificationBell } from "../notifications/NotificationBell";
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-20 h-14 bg-surface flex items-center px-6 shadow-[0_1px_0_0_color-mix(in_srgb,var(--color-border)_60%,transparent)]">
+    <header className="sticky top-0 z-20 h-14 bg-surface flex items-center gap-4 px-6 shadow-[0_1px_0_0_color-mix(in_srgb,var(--color-border)_60%,transparent)]">
       <div id={PAGE_HEADER_SLOT_ID} className="flex-1 min-w-0" />
+      <NotificationBell />
     </header>
   );
 }

--- a/frontend/app/components/notifications/NotificationBell.tsx
+++ b/frontend/app/components/notifications/NotificationBell.tsx
@@ -1,0 +1,472 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import Link from "next/link";
+import {
+  Bell,
+  Calendar,
+  Database,
+  FileText,
+  Heart,
+  Smartphone,
+  Wallet,
+  Users,
+} from "lucide-react";
+import { apiClient } from "@/app/lib/api";
+
+// ─── Tipos ──────────────────────────────────────────────────────────────────
+
+/** Espelha apps/core/serializers.py::NotificationSerializer. */
+export type Notification = {
+  id: number;
+  tipo: string;
+  titulo: string;
+  mensagem: string;
+  link: string;
+  modulo_origem: string;
+  evento: string;
+  enviado_em: string | null;
+  lido_em: string | null;
+  status: string;
+  tentativas: number;
+};
+
+type UnreadCountResponse = { count: number };
+type NotificationListResponse = { results: Notification[] };
+
+// ─── Constantes ─────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 60_000;
+const PULSE_DURATION_MS = 2_000;
+const LIST_PAGE_SIZE = 10;
+
+// Ícone do módulo de origem — switch retornando JSX direto (mesma abordagem do
+// DashboardCardIcon). Evita derivar um componente em tempo de render, o que
+// dispararia a regra react-hooks/static-components.
+function ModuleOriginIcon({ modulo }: { modulo: string }) {
+  const props = { className: "h-5 w-5", "aria-hidden": true as const };
+  switch (modulo.trim().toLowerCase()) {
+    case "sca":
+      return <Smartphone {...props} />;
+    case "sgd":
+      return <FileText {...props} />;
+    case "sge":
+      return <Calendar {...props} />;
+    case "sgf":
+      return <Wallet {...props} />;
+    case "sgp":
+      return <Users {...props} />;
+    case "sgs":
+      return <Heart {...props} />;
+    case "core":
+      return <Database {...props} />;
+    default:
+      return <Bell {...props} />;
+  }
+}
+
+// ─── Tempo relativo (pt-BR) ─────────────────────────────────────────────────
+
+const rtf = new Intl.RelativeTimeFormat("pt-BR", { numeric: "auto" });
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "";
+  const diffSec = Math.round((new Date(iso).getTime() - Date.now()) / 1000);
+  const abs = Math.abs(diffSec);
+  if (abs < 60) return "agora";
+  const min = Math.round(diffSec / 60);
+  if (Math.abs(min) < 60) return rtf.format(min, "minute");
+  const hour = Math.round(diffSec / 3600);
+  if (Math.abs(hour) < 24) return rtf.format(hour, "hour");
+  return rtf.format(Math.round(diffSec / 86_400), "day");
+}
+
+function isUnread(n: Notification): boolean {
+  return n.lido_em === null;
+}
+
+// ─── Hook: contagem de não-lidas com polling sensível à visibilidade ─────────
+
+function useUnreadCount() {
+  const [count, setCount] = useState(0);
+  // Guarda o valor anterior para detectar AUMENTO (dispara o pulso).
+  const prevRef = useRef(0);
+  // A primeira leitura apenas estabelece a linha de base — não pulsa.
+  const initializedRef = useRef(false);
+  const [pulsing, setPulsing] = useState(false);
+  const pulseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const applyCount = useCallback((next: number) => {
+    if (initializedRef.current && next > prevRef.current) {
+      setPulsing(true);
+      if (pulseTimer.current) clearTimeout(pulseTimer.current);
+      pulseTimer.current = setTimeout(() => setPulsing(false), PULSE_DURATION_MS);
+    }
+    initializedRef.current = true;
+    prevRef.current = next;
+    setCount(next);
+  }, []);
+
+  const fetchCount = useCallback(async () => {
+    try {
+      const res = await apiClient("/api/v1/notifications/me/unread-count/");
+      const data: UnreadCountResponse = await res.json();
+      applyCount(data.count);
+    } catch {
+      // Silencioso: o polling tenta de novo no próximo ciclo.
+    }
+  }, [applyCount]);
+
+  // Atualização local imediata (otimista) sem esperar o próximo poll.
+  const setCountLocal = useCallback((next: number) => {
+    prevRef.current = next;
+    setCount(next);
+  }, []);
+
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | null = null;
+
+    function start() {
+      if (interval) return;
+      void fetchCount();
+      interval = setInterval(() => void fetchCount(), POLL_INTERVAL_MS);
+    }
+
+    function stop() {
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    }
+
+    function onVisibility() {
+      // Só faz polling com a aba visível; pausa em background.
+      if (document.visibilityState === "visible") start();
+      else stop();
+    }
+
+    onVisibility();
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      stop();
+      if (pulseTimer.current) clearTimeout(pulseTimer.current);
+    };
+  }, [fetchCount]);
+
+  return { count, pulsing, refresh: fetchCount, setCountLocal };
+}
+
+// ─── Subcomponente: item da lista ───────────────────────────────────────────
+
+function NotificationItem({
+  notification,
+  onRead,
+  onClose,
+}: {
+  notification: Notification;
+  onRead: (n: Notification) => void;
+  onClose: () => void;
+}) {
+  const unread = isUnread(notification);
+  const hasLink = notification.link.length > 0;
+  const internal = notification.link.startsWith("/");
+
+  const content = (
+    <>
+      <span className="mt-0.5 shrink-0 text-text-muted">
+        <ModuleOriginIcon modulo={notification.modulo_origem} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          {unread && (
+            <span
+              className="h-2 w-2 shrink-0 rounded-full bg-info-text"
+              aria-hidden="true"
+            />
+          )}
+          <span className="truncate text-sm font-medium text-text">
+            {notification.titulo}
+          </span>
+        </span>
+        <span className="mt-0.5 line-clamp-2 text-xs text-text-muted">
+          {notification.mensagem}
+        </span>
+        <span className="mt-1 block text-micro text-text-muted">
+          {relativeTime(notification.enviado_em)}
+        </span>
+      </span>
+    </>
+  );
+
+  const className = [
+    "flex w-full items-start gap-3 px-4 py-3 text-left transition-colors",
+    "hover:bg-surface-muted focus-visible:outline-none focus-visible:bg-surface-muted",
+    unread ? "bg-surface-warm" : "bg-surface",
+  ].join(" ");
+
+  // Item com link navega (e fecha o dropdown); sem link, só marca como lido.
+  function handleNavigate() {
+    onRead(notification);
+    onClose();
+  }
+
+  // Link interno → navegação SPA; link externo → âncora; sem link → botão.
+  if (hasLink && internal) {
+    return (
+      <li>
+        <Link href={notification.link} className={className} onClick={handleNavigate}>
+          {content}
+        </Link>
+      </li>
+    );
+  }
+  if (hasLink) {
+    return (
+      <li>
+        <a href={notification.link} className={className} onClick={handleNavigate}>
+          {content}
+        </a>
+      </li>
+    );
+  }
+  return (
+    <li>
+      <button type="button" className={className} onClick={() => onRead(notification)}>
+        {content}
+      </button>
+    </li>
+  );
+}
+
+// ─── NotificationBell ───────────────────────────────────────────────────────
+
+export function NotificationBell() {
+  const { count, pulsing, refresh, setCountLocal } = useUnreadCount();
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const panelId = useId();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const loadList = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiClient(
+        `/api/v1/notifications/me/?limit=${LIST_PAGE_SIZE}`,
+      );
+      const data: NotificationListResponse = await res.json();
+      setItems(data.results);
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Carrega a lista ao abrir. loadList faz setState (loading) de forma síncrona;
+  // é uma busca legítima disparada pela abertura — mesmo padrão já adotado no
+  // repo (PageHeader, ThemeToggle).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (open) void loadList();
+  }, [open, loadList]);
+
+  // Esc fecha + clique fora fecha.
+  useEffect(() => {
+    if (!open) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+        buttonRef.current?.focus();
+        return;
+      }
+      // Foco preso: cicla o Tab dentro do painel.
+      if (e.key === "Tab" && panelRef.current) {
+        const focusables = panelRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    function onPointerDown(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        !panelRef.current?.contains(target) &&
+        !buttonRef.current?.contains(target)
+      ) {
+        close();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("mousedown", onPointerDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("mousedown", onPointerDown);
+    };
+  }, [open, close]);
+
+  // Move o foco para dentro do painel ao abrir.
+  useEffect(() => {
+    if (open) panelRef.current?.focus();
+  }, [open]);
+
+  // Marca uma notificação como lida — otimista, com rollback em erro.
+  const markRead = useCallback(
+    (notification: Notification) => {
+      if (isUnread(notification)) {
+        const snapshot = items;
+        const snapshotCount = count;
+        const nowIso = new Date().toISOString();
+        setItems((prev) =>
+          prev.map((n) => (n.id === notification.id ? { ...n, lido_em: nowIso } : n)),
+        );
+        setCountLocal(Math.max(0, count - 1));
+
+        void apiClient(`/api/v1/notifications/${notification.id}/read/`, {
+          method: "PATCH",
+        }).catch(() => {
+          // Rollback visual + ressincroniza a contagem com o servidor.
+          setItems(snapshot);
+          setCountLocal(snapshotCount);
+          void refresh();
+        });
+      }
+    },
+    [items, count, refresh, setCountLocal],
+  );
+
+  // Marca todas como lidas — otimista, com rollback em erro.
+  const markAllRead = useCallback(() => {
+    const snapshot = items;
+    const snapshotCount = count;
+    const nowIso = new Date().toISOString();
+    setItems((prev) =>
+      prev.map((n) => (n.lido_em ? n : { ...n, lido_em: nowIso })),
+    );
+    setCountLocal(0);
+
+    void apiClient("/api/v1/notifications/mark-all-read/", {
+      method: "POST",
+    }).catch(() => {
+      setItems(snapshot);
+      setCountLocal(snapshotCount);
+      void refresh();
+    });
+  }, [items, count, refresh, setCountLocal]);
+
+  const badgeLabel = count > 9 ? "9+" : String(count);
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={`Notificações, ${count} não lidas`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        className="relative inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-surface-muted hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+      >
+        <Bell className="h-5 w-5" aria-hidden="true" />
+
+        {count > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 inline-flex">
+            {/* Pulso de 2s ao chegar notificação nova; oculto com reduced-motion. */}
+            {pulsing && (
+              <span className="absolute inset-0 inline-flex h-full w-full animate-ping rounded-full bg-error opacity-75 motion-reduce:hidden" />
+            )}
+            <span className="relative inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-error px-1 text-micro font-semibold text-white">
+              {badgeLabel}
+            </span>
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          id={panelId}
+          role="dialog"
+          aria-label="Notificações"
+          tabIndex={-1}
+          className="absolute right-0 top-full z-30 mt-2 flex max-h-96 w-80 flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-md outline-none"
+        >
+          <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+            <h2 className="text-sm font-semibold text-text">Notificações</h2>
+          </header>
+
+          <ul
+            aria-live="polite"
+            className="flex-1 divide-y divide-border overflow-y-auto"
+          >
+            {loading && items.length === 0 ? (
+              <li className="px-4 py-6 text-center text-sm text-text-muted">
+                Carregando…
+              </li>
+            ) : items.length === 0 ? (
+              <li className="flex flex-col items-center gap-2 px-4 py-8 text-center">
+                <Bell className="h-8 w-8 text-text-muted" aria-hidden="true" />
+                <span className="text-sm text-text-muted">
+                  Nenhuma notificação ainda
+                </span>
+              </li>
+            ) : (
+              items.map((n) => (
+                <NotificationItem
+                  key={n.id}
+                  notification={n}
+                  onRead={markRead}
+                  onClose={close}
+                />
+              ))
+            )}
+          </ul>
+
+          <footer className="flex shrink-0 items-center justify-between gap-2 border-t border-border px-4 py-2">
+            <button
+              type="button"
+              onClick={markAllRead}
+              className="rounded-sm text-xs font-medium text-primary transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              Marcar todas como lidas
+            </button>
+            <Link
+              href="/notificacoes"
+              onClick={close}
+              className="rounded-sm text-xs font-medium text-text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              Ver todas
+            </Link>
+          </footer>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Descrição

Implementa o **`NotificationBell` (FE-03)** no Header: um sino de notificações com badge, dropdown das últimas notificações, marcação como lida (otimista) e polling da contagem de não-lidas. Inclui o placeholder da rota `/notificacoes` para o link "Ver todas".

Branch baseada em `issue-52` (frontend do André) para não bloquear nenhuma das duas frentes.

## O que foi feito

- `app/components/notifications/NotificationBell.tsx` — componente completo (sino + badge + dropdown).
- `app/components/layout/Header.tsx` — sino posicionado à direita do Header.
- `app/(protected)/notificacoes/page.tsx` — placeholder da central de notificações.

## Critérios de aceitação

- [x] Polling de 60s no `/unread-count/`, **pausado em background** (`document.visibilityState` + `visibilitychange`).
- [x] Badge aparece só com `count > 0`; mostra **`9+`** quando `> 9`.
- [x] Dropdown abre/fecha com **Esc** (e clique fora); **foco preso** enquanto aberto, com retorno do foco ao sino ao fechar.
- [x] **Pulso de 2s** ao detectar aumento do count; respeita **`prefers-reduced-motion`** (`motion-reduce:hidden`). Não dispara na primeira carga.
- [x] Marcar como lida atualiza a UI **otimisticamente** (PATCH), com **rollback** em caso de erro.
- [x] "Marcar todas como lidas" (POST) — também otimista com rollback.
- [x] Link do item, quando presente, navega para a tela do recurso (SPA para link interno, âncora para externo).
- [x] Estado vazio do dropdown ("Nenhuma notificação ainda") com ícone amigável.
- [x] `aria-label="Notificações, X não lidas"` no botão; `aria-live="polite"` na lista.
- [x] Não-lida com fundo `surface-warm` (`#F5EFE0`) + ponto azul; tempo relativo (pt-BR); ícone do módulo de origem.

## Observações técnicas

- **`?limit=10` em vez de `?page_size=10`:** o backend usa `LimitOffsetPagination`, cujo parâmetro é `limit`. `page_size` (citado na issue) seria ignorado. Vale alinhar a doc da issue com o backend.
- **Polling sem SWR/TanStack Query:** nenhuma das duas libs está instalada no projeto. Para não introduzir dependência nova, o polling foi feito com um hook próprio (`useUnreadCount`) — atende todos os critérios (60s, pausa em background, detecção de aumento p/ o pulso).
- Ícone do módulo de origem via `switch` retornando JSX (mesma abordagem do `DashboardCardIcon`), evitando a regra `react-hooks/static-components`.

## Verificação

- `npx tsc --noEmit` — limpo.
- `npm run lint` (projeto inteiro) — limpo.
- `next build` — compila e passa no TypeScript. (As falhas remanescentes do build são pré-existentes da branch base: `next.config.ts` com `webpack` custom sob Turbopack, e `/styleguide` com `notFound()` em produção — fora do escopo desta issue.)

## Como testar

1. Subir a stack e logar.
2. Criar notificações para o usuário (admin/seed).
3. Conferir: badge com contador, pulso ao chegar nova, dropdown (Esc/clique-fora/foco), marcar como lida e marcar todas, estado vazio, e o link "Ver todas" levando a `/notificacoes`.
